### PR TITLE
Use -m rather than --mode when installing for Busybox compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Author: David Weinehall <david.weinehall@nokia.com>
 
 INSTALL_DIR := install -d
-INSTALL_DATA := install -o root -g root --mode=644
+INSTALL_DATA := install -o root -g root -m 644
 
 DOXYGEN := doxygen
 


### PR DESCRIPTION
Busybox's `install` doesn't support `--mode=644`, but it does support `-m 644`.